### PR TITLE
NSA-1357 - Fix issue downloading large backup

### DIFF
--- a/src/app/osaRestore/index.js
+++ b/src/app/osaRestore/index.js
@@ -207,9 +207,6 @@ const storeFiles = async (backupLocation) => {
 const downloadAndRestoreOsaBackup = async () => {
   try {
     const backupPath = await downloadAndDecryptBackupToDisk();
-    // const encryptedData = await downloadBackup();
-    // const data = await decryptData(encryptedData);
-    // const backupPath = await saveBackup(data);
     await dropTablesAndViews();
     await restoreBackup(backupPath);
     await storeFiles(backupPath);


### PR DESCRIPTION
Download 1MB ranges from S3 at a time and decrypt that chunk and write straight to disk. This should avoid:

1. S3 rejecting the getObject request
2. The node process trying to load too much data into memory